### PR TITLE
get_max_fraction() and get_min_fraction() instead of 1 and 0

### DIFF
--- a/behaviour.php
+++ b/behaviour.php
@@ -34,7 +34,7 @@ class qbehaviour_deferredallnothing extends qbehaviour_deferredfeedback {
         $fraction = $pendingstep->get_fraction();
         if ($keep == question_attempt::KEEP &&
                 $fraction != null &&
-                $fraction != $this->question->get_max_fraction()) {
+                abs($this->question->get_max_fraction() - $fraction) > 0.000001) {
             $pendingstep->set_fraction($this->question->get_min_fraction());
             $pendingstep->set_state(question_state::$gradedwrong);
         }

--- a/behaviour.php
+++ b/behaviour.php
@@ -34,8 +34,8 @@ class qbehaviour_deferredallnothing extends qbehaviour_deferredfeedback {
         $fraction = $pendingstep->get_fraction();
         if ($keep == question_attempt::KEEP &&
                 $fraction != null &&
-                $fraction != 1) {
-            $pendingstep->set_fraction(0);
+                $fraction != $this->question->get_max_fraction()) {
+            $pendingstep->set_fraction($this->question->get_min_fraction());
             $pendingstep->set_state(question_state::$gradedwrong);
         }
         return $keep;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qbehaviour_deferredallnothing';
-$plugin->version   = 2015051500;
+$plugin->version   = 2015051502;
 
 $plugin->requires  = 2013111800;
 $plugin->dependencies = array(

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'qbehaviour_deferredallnothing';
-$plugin->version   = 2015051502;
+$plugin->version   = 2015051503;
 
 $plugin->requires  = 2013111800;
 $plugin->dependencies = array(


### PR DESCRIPTION
I suggest that it's better to use get_max_fraction() and get_min_fraction() instead of 1 and 0. Builtin question types returns 1 and 0, but maybe some custom types may use other max and min value.
When comparing fraction to 1 tolerance must be taking into account. If you have 3 rights answers with 0.3333333 they give 0.9999999, resulting in not right answer instead of right
